### PR TITLE
Include the `SameSite` attribute.

### DIFF
--- a/src/js/module.js
+++ b/src/js/module.js
@@ -195,7 +195,7 @@ class Cead {
   setCookie(status) {
     let expiry = new Date();
     expiry.setFullYear(expiry.getFullYear() + 1);
-    document.cookie = `${this.config.cookie}=${status}; path=/; domain=.${document.domain}; Expires=${expiry.toUTCString()};`;
+    document.cookie = `${this.config.cookie}=${status}; path=/; domain=.${document.domain}; Expires=${expiry.toUTCString()}; SameSite=Lax`;
   }
 
   /**


### PR DESCRIPTION
`document.cookie` should explicitly include the `SameSite` attribute.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

> You should explicitly communicate the intended SameSite policy for your cookie (rather than relying on browsers to apply SameSite=Lax automatically). This will also improve the experience across browsers as not all of them default to Lax yet.